### PR TITLE
Add support for soft and weak reference types

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   - capping the number of pooled objects
   - creating new objects lazily, as needed
   - time-based pool eviction (idle instances)
+  - GC-based pool eviction (soft and weak references)
   - efficient thread-safety
 
 * * *

--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,14 @@ scalacOptions ++= Seq(
   "-language:higherKinds",
   "-language:implicitConversions")
 
+val javaVersion = settingKey[String]("Java version")
+javaVersion := System.getProperty("java.version")
+
+unmanagedSourceDirectories in Compile <+= (javaVersion, sourceDirectory in Compile) {
+  case (v, dir) if v startsWith "1.8" => dir / "java_8"
+  case (v, dir) if v startsWith "1.7" => dir / "java_7"
+}
+
 scalacOptions in Test ++= Seq("-Yrangepos")
 
 fork := true

--- a/src/main/java_7/io/github/andrebeat/pool/Adder.scala
+++ b/src/main/java_7/io/github/andrebeat/pool/Adder.scala
@@ -1,0 +1,13 @@
+package io.github.andrebeat.pool
+
+import java.util.concurrent.atomic.AtomicLong
+
+private[pool] class Jdk8Adder extends Adder {
+  def increment() = ???
+  def count() = ???
+}
+
+private[pool] class Jdk7Adder extends AtomicLong with Adder {
+  def increment() = this.incrementAndGet
+  def count() = this.get
+}

--- a/src/main/java_8/io/github/andrebeat/pool/Adder.scala
+++ b/src/main/java_8/io/github/andrebeat/pool/Adder.scala
@@ -1,0 +1,12 @@
+package io.github.andrebeat.pool
+
+import java.util.concurrent.atomic.{LongAdder, AtomicLong}
+
+private[pool] class Jdk8Adder extends LongAdder with Adder {
+  def count() = this.sum
+}
+
+private[pool] class Jdk7Adder extends AtomicLong with Adder {
+  def increment() = this.incrementAndGet
+  def count() = this.get
+}

--- a/src/main/scala/io/github/andrebeat/pool/Adder.scala
+++ b/src/main/scala/io/github/andrebeat/pool/Adder.scala
@@ -1,0 +1,37 @@
+package io.github.andrebeat.pool
+
+import java.util.concurrent.atomic.{ AtomicLong, LongAdder }
+
+/**
+  * A trait to abstract over two distinct implementations of a long adder.
+  *
+  * The JDK8 introduces a new class `LongAdder` which when only using the `sum()` and `increment()`
+  * methods is guaranteed to be sequentially consistent and a lot faster than an `AtomicLong`.
+  * (http://concurrencyfreaks.blogspot.se/2013/09/longadder-is-not-sequentially-consistent.html).
+  *
+  *  On JDK7 an `AtomicLong` is used to implement this trait.
+  */
+private[pool] trait Adder {
+  def increment(): Unit
+  def count(): Long
+}
+
+private[pool] class Jdk7Adder extends AtomicLong with Adder {
+  def increment() = this.incrementAndGet
+  def count() = this.get
+}
+
+private[pool] class Jdk8Adder extends LongAdder with Adder {
+  def count() = this.sum
+}
+
+private[pool] object Adder {
+  def apply() =
+    try {
+      this.getClass.getClassLoader().loadClass("java.util.concurrent.atomic.LongAdder")
+      new Jdk8Adder()
+    } catch {
+      case e: ClassNotFoundException =>
+        new Jdk7Adder()
+    }
+}

--- a/src/main/scala/io/github/andrebeat/pool/Adder.scala
+++ b/src/main/scala/io/github/andrebeat/pool/Adder.scala
@@ -1,28 +1,19 @@
 package io.github.andrebeat.pool
 
-import java.util.concurrent.atomic.{ AtomicLong, LongAdder }
-
 /**
   * A trait to abstract over two distinct implementations of a long adder.
   *
   * The JDK8 introduces a new class `LongAdder` which when only using the `sum()` and `increment()`
   * methods is guaranteed to be sequentially consistent and a lot faster than an `AtomicLong`.
   * (http://concurrencyfreaks.blogspot.se/2013/09/longadder-is-not-sequentially-consistent.html).
+  * On JDK7 an `AtomicLong` is used to implement this trait.
   *
-  *  On JDK7 an `AtomicLong` is used to implement this trait.
+  * The implementations of the `Adder`s are in different files to allow conditional compilation on
+  * JDK7 and JDK8.
   */
 private[pool] trait Adder {
   def increment(): Unit
   def count(): Long
-}
-
-private[pool] class Jdk7Adder extends AtomicLong with Adder {
-  def increment() = this.incrementAndGet
-  def count() = this.get
-}
-
-private[pool] class Jdk8Adder extends LongAdder with Adder {
-  def count() = this.sum
 }
 
 private[pool] object Adder {

--- a/src/main/scala/io/github/andrebeat/pool/ArrayBlockingQueuePool.scala
+++ b/src/main/scala/io/github/andrebeat/pool/ArrayBlockingQueuePool.scala
@@ -41,7 +41,8 @@ abstract class ArrayBlockingQueuePool[A <: AnyRef](
       * consumed.
       */
     def destroy(): Unit = {
-      r.toOption.map(pool.destroy)
+      r.toOption.map(pool.dispose)
+      decrementLive
       consume()
     }
 

--- a/src/main/scala/io/github/andrebeat/pool/ArrayBlockingQueuePool.scala
+++ b/src/main/scala/io/github/andrebeat/pool/ArrayBlockingQueuePool.scala
@@ -11,12 +11,50 @@ import scala.concurrent.duration.{ Duration, NANOSECONDS }
   * underlying data structure to implement the pool interface. Furthermore, for synchronization and
   * tracking of live instances an `AtomicInteger` is used. No locks are used in this implementation.
   *
-  * The type of items inserted in the queue is generic and implementations of this class must
-  * provide methods to create and acquire these items. Additionally, there's an "hook" that's called
-  * whenever an item is succesfully inserted into the queue.
+  * The type of items inserted in the queue must implement the `Item` interface. This class defines
+  * methods for consuming the item (e.g. disposing of any resources associated with it) and a method
+  * that's called whenever an item is successfully inserted into the queue (useful for triggering a
+  * side-effect). This class is also responsible for dealing with the reference type that's wrapping
+  * the value (i.e. ensure calling its destructor if the value is defined).
   */
-abstract class ArrayBlockingQueuePool[A <: AnyRef](val capacity: Int) extends Pool[A] {
-  type Item
+abstract class ArrayBlockingQueuePool[A <: AnyRef](
+    val capacity: Int,
+    val referenceType: ReferenceType
+) extends Pool[A] { pool =>
+  abstract protected class Item(val r: Ref[A]) {
+    def isDefined(): Boolean = r.toOption().isDefined
+
+    /**
+      * This method should only be called from this class and it is guaranteed that the value is
+      * always defined before calling. Whenever this method is called it is considered that the
+      * value is consumed.
+      */
+    def get(): A = {
+      val a = r.toOption().get
+      consume()
+      a
+    }
+
+    /**
+      * This method is only called whenever using a Soft/Weak reference that was invalidated by the
+      * garbage collector. Whenever this method is called it is considered that the value is
+      * consumed.
+      */
+    def destroy(): Unit = {
+      r.toOption.map(pool.destroy)
+      consume()
+    }
+
+    /**
+      * This method is called whenever the item is successfully inserted in the queue.
+      */
+    def offerSuccess(): Unit
+
+    /**
+      * This method is called whenever the item is consumed from the queue.
+      */
+    def consume(): Unit
+  }
 
   protected[this] val items = new ArrayBlockingQueue[Item](capacity)
   private[this] val live = new AtomicInteger(0)
@@ -28,13 +66,11 @@ abstract class ArrayBlockingQueuePool[A <: AnyRef](val capacity: Int) extends Po
     decrementLive
   }
 
-  protected[this] def acquireItem(i: Item): A
-  protected[this] def createItem(a: A): Item
-  protected[this] def offerSuccess(i: Item): Unit
+  protected[this] def newItem(a: A): Item
 
   @inline private[this] def tryOffer(a: A) = {
-    val item = createItem(a)
-    if (items.offer(item)) offerSuccess(item)
+    val item = newItem(a)
+    if (items.offer(item)) item.offerSuccess()
     else destroy(a)
   }
 
@@ -49,12 +85,20 @@ abstract class ArrayBlockingQueuePool[A <: AnyRef](val capacity: Int) extends Po
     }
   }
 
-  @inline private[this] def createOr(a: => Option[Item]): Option[A] = {
+  @inline private[this] def createOr(io: => Option[Item]): Option[A] = {
     live.getAndIncrement match {
       case n if n < capacity =>
         Some(factory())
       case _ =>
-        decrementLive; a.map(acquireItem)
+        decrementLive;
+
+        io match {
+          case Some(i) if i.isDefined => Some(i.get)
+          case Some(i) =>
+            i.destroy()
+            createOr(io)
+          case _ => None
+        }
     }
   }
 
@@ -70,7 +114,7 @@ abstract class ArrayBlockingQueuePool[A <: AnyRef](val capacity: Int) extends Po
   @tailrec final def drain() = {
     val i = Option(items.poll())
     if (i.nonEmpty) {
-      destroy(acquireItem(i.get))
+      i.get.destroy()
       drain()
     }
   }

--- a/src/main/scala/io/github/andrebeat/pool/ExpiringPool.scala
+++ b/src/main/scala/io/github/andrebeat/pool/ExpiringPool.scala
@@ -2,7 +2,7 @@ package io.github.andrebeat.pool
 
 import java.util.{ Timer, TimerTask }
 import java.util.concurrent.ArrayBlockingQueue
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.{ AtomicInteger, LongAdder }
 import scala.annotation.tailrec
 import scala.concurrent.duration.{ Duration, NANOSECONDS }
 
@@ -21,26 +21,41 @@ class ExpiringPool[A <: AnyRef](
 
   implicit private[this] def function2TimerTask[A](f: () => A) = new TimerTask() { def run() = f() }
 
-  final protected class ExpiringItem(r: Ref[A], val timerTask: TimerTask = () => {}) extends Item(r) {
+  final protected class ExpiringItem(
+      val id: Long,
+      r: Ref[A],
+      val timerTask: TimerTask = () => {}
+  ) extends Item(r) {
+
     def consume() = timerTask.cancel()
 
     def offerSuccess() = timer.schedule(timerTask, maxIdleTime.toMillis)
 
     override def equals(that: Any) = that match {
-      case that: ExpiringItem @unchecked => this.r eq that.r
+      case that: ExpiringItem @unchecked => this.id == that.id
       case _ => false
     }
   }
 
   private[this] val timer = new Timer(s"scala-pool-${ExpiringPool.count.getAndIncrement}", true)
 
+  // Since we're only using the `sum()` and `increment()` methods, the `LongAdder` is guaranteed to
+  // be sequentially consistent (and faster than `AtomicLong`).
+  // http://concurrencyfreaks.blogspot.se/2013/09/longadder-is-not-sequentially-consistent.html
+  private[this] val adder = new LongAdder()
+
   @inline protected[this] def factory() = _factory()
   @inline protected[this] def dispose(a: A) = _dispose(a)
   @inline protected[this] def reset(a: A) = _reset(a)
 
   @inline protected[this] def newItem(a: A) = {
+    adder.increment()
+    val id = adder.sum()
     val r = Ref(a, referenceType)
-    new ExpiringItem(r, () => if (items.remove(new ExpiringItem(r))) destroy(a))
+    new ExpiringItem(id, r, () => {
+      val i = new ExpiringItem(id, r)
+      if (items.remove(i)) i.destroy()
+    })
   }
 }
 

--- a/src/main/scala/io/github/andrebeat/pool/Pool.scala
+++ b/src/main/scala/io/github/andrebeat/pool/Pool.scala
@@ -81,6 +81,11 @@ trait Pool[A <: AnyRef] {
   def tryAcquire(atMost: Duration): Option[Lease[A]]
 
   /**
+    * Returns the `ReferenceType` of the objects stored in the pool.
+    */
+  def referenceType: ReferenceType
+
+  /**
     * Acquire a lease for an object blocking if none is available.
     * @return a lease for an object from this pool.
     */
@@ -99,6 +104,10 @@ trait Pool[A <: AnyRef] {
 
   /**
     * Returns the number of objects in the pool.
+    *
+    * The value returned by this method is only accurate when the `referenceType` is `Strong`, since
+    * GC-based eviction is checked only when trying to acquire an object.
+    *
     * @return the number of objects in the pool.
     */
   def size(): Int
@@ -112,12 +121,20 @@ trait Pool[A <: AnyRef] {
   /**
     * Returns the number of live objects, i.e. the number of currently pooled objects plus leased
     * objects.
+    *
+    * The value returned by this method is only accurate when the `referenceType` is `Strong`, since
+    * GC-based eviction is checked only when trying to acquire an object.
+    *
     * @return the number of live objects.
     */
   def live(): Int
 
   /**
     * Returns the number of leased objects.
+    *
+    * The value returned by this method is only accurate when the `referenceType` is `Strong`, since
+    * GC-based eviction is checked only when trying to acquire an object.
+    *
     * @return the number of leased objects.
     */
   def leased(): Int = live - size

--- a/src/main/scala/io/github/andrebeat/pool/Ref.scala
+++ b/src/main/scala/io/github/andrebeat/pool/Ref.scala
@@ -1,0 +1,36 @@
+package io.github.andrebeat.pool
+
+import java.lang.ref.{ SoftReference, WeakReference }
+
+sealed private[pool] trait Ref[A <: AnyRef] {
+  def toOption(): Option[A]
+}
+
+final private[pool] class StrongRef[A <: AnyRef](val a: A) extends Ref[A] {
+  def toOption() = Some(a)
+}
+
+final private[pool] class SoftRef[A <: AnyRef](val a: SoftReference[A]) extends Ref[A] {
+  def toOption() = Option(a.get())
+}
+
+final private[pool] class WeakRef[A <: AnyRef](val a: WeakReference[A]) extends Ref[A] {
+  def toOption() = Option(a.get())
+}
+
+private[pool] object Ref {
+  def apply[A <: AnyRef](a: A, t: ReferenceType) =
+    t match {
+      case Strong => new StrongRef(a)
+      case Soft => new SoftRef(new SoftReference(a))
+      case Weak => new WeakRef(new WeakReference(a))
+    }
+}
+
+/**
+  * An enum-type for Java reference types.
+  */
+sealed trait ReferenceType
+case object Strong extends ReferenceType
+case object Soft extends ReferenceType
+case object Weak extends ReferenceType

--- a/src/main/scala/io/github/andrebeat/pool/SimplePool.scala
+++ b/src/main/scala/io/github/andrebeat/pool/SimplePool.scala
@@ -1,9 +1,6 @@
 package io.github.andrebeat.pool
 
-import java.util.concurrent.ArrayBlockingQueue
-import java.util.concurrent.atomic.AtomicInteger
 import scala.annotation.tailrec
-import scala.concurrent.duration.{ Duration, NANOSECONDS }
 
 /**
   * A simple object pool that creates the objects as needed until a maximum number of objects has

--- a/src/main/scala/io/github/andrebeat/pool/SimplePool.scala
+++ b/src/main/scala/io/github/andrebeat/pool/SimplePool.scala
@@ -9,17 +9,24 @@ import scala.concurrent.duration.{ Duration, NANOSECONDS }
   * A simple object pool that creates the objects as needed until a maximum number of objects has
   * been created.
   */
-class SimplePool[A <: AnyRef](capacity: Int, _factory: () => A, _reset: A => Unit, _dispose: A => Unit)
-    extends ArrayBlockingQueuePool[A](capacity) {
-  type Item = A
+class SimplePool[A <: AnyRef](
+    capacity: Int,
+    referenceType: ReferenceType,
+    _factory: () => A,
+    _reset: A => Unit,
+    _dispose: A => Unit
+) extends ArrayBlockingQueuePool[A](capacity, referenceType) {
 
   @inline protected[this] def factory() = _factory()
   @inline protected[this] def dispose(a: A) = _dispose(a)
   @inline protected[this] def reset(a: A) = _reset(a)
 
-  @inline protected[this] def acquireItem(a: Item) = a
-  @inline protected[this] def createItem(a: A) = a
-  @inline protected[this] def offerSuccess(i: Item) = {}
+  final protected class SimpleItem(a: Ref[A]) extends Item(a) {
+    def consume() = {}
+    def offerSuccess() = {}
+  }
+
+  @inline protected[this] def newItem(a: A): Item = new SimpleItem(Ref(a, referenceType))
 }
 
 /**
@@ -29,8 +36,9 @@ object SimplePool {
   def apply[A <: AnyRef](
     capacity: Int,
     factory: () => A,
+    referenceType: ReferenceType = Strong,
     reset: A => Unit = { _: A => () },
     dispose: A => Unit = { _: A => () }
   ) =
-    new SimplePool(capacity, factory, reset, dispose)
+    new SimplePool(capacity, referenceType, factory, reset, dispose)
 }

--- a/src/test/scala/io/github/andrebeat/pool/ExpiringPoolSpec.scala
+++ b/src/test/scala/io/github/andrebeat/pool/ExpiringPoolSpec.scala
@@ -8,7 +8,7 @@ class ExpiringPoolSpec extends PoolSpec[ExpiringPool] {
     factory: () => A,
     reset: A => Unit = { _: A => () },
     dispose: A => Unit = { _: A => () }
-  ) = ExpiringPool(capacity, 42.hours, factory, reset, dispose)
+  ) = ExpiringPool(capacity, 42.hours, factory, Strong, reset, dispose)
 
   "A ExpiringPool" should {
     "evict idle objects" >> {

--- a/src/test/scala/io/github/andrebeat/pool/ExpiringPoolSpec.scala
+++ b/src/test/scala/io/github/andrebeat/pool/ExpiringPoolSpec.scala
@@ -6,9 +6,10 @@ class ExpiringPoolSpec extends PoolSpec[ExpiringPool] {
   def Pool[A <: AnyRef](
     capacity: Int,
     factory: () => A,
+    referenceType: ReferenceType = Strong,
     reset: A => Unit = { _: A => () },
     dispose: A => Unit = { _: A => () }
-  ) = ExpiringPool(capacity, 42.hours, factory, Strong, reset, dispose)
+  ) = ExpiringPool(capacity, 42.hours, factory, referenceType, reset, dispose)
 
   "A ExpiringPool" should {
     "evict idle objects" >> {

--- a/src/test/scala/io/github/andrebeat/pool/SimplePoolSpec.scala
+++ b/src/test/scala/io/github/andrebeat/pool/SimplePoolSpec.scala
@@ -4,7 +4,8 @@ class SimplePoolSpec extends PoolSpec[SimplePool] {
   def Pool[A <: AnyRef](
     capacity: Int,
     factory: () => A,
+    referenceType: ReferenceType = Strong,
     reset: A => Unit = { _: A => () },
     dispose: A => Unit = { _: A => () }
-  ) = SimplePool(capacity, factory, Strong, reset, dispose)
+  ) = SimplePool(capacity, factory, referenceType, reset, dispose)
 }

--- a/src/test/scala/io/github/andrebeat/pool/SimplePoolSpec.scala
+++ b/src/test/scala/io/github/andrebeat/pool/SimplePoolSpec.scala
@@ -6,5 +6,5 @@ class SimplePoolSpec extends PoolSpec[SimplePool] {
     factory: () => A,
     reset: A => Unit = { _: A => () },
     dispose: A => Unit = { _: A => () }
-  ) = SimplePool(capacity, factory, reset, dispose)
+  ) = SimplePool(capacity, factory, Strong, reset, dispose)
 }


### PR DESCRIPTION
Add supporting for storing objects in the pool as `Soft` and `Weak` references so that they can be "evicted" from the pool by the garbage collector when needed.
