### PR TITLE
Fix eager object creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ To use it in an existing SBT project, add the following dependency to your `buil
 libraryDependencies += "io.github.andrebeat" %% "scala-pool" % "0.1-SNAPSHOT"
 ```
 
+Currently, the library has no external dependencies apart from the Java and Scala standard
+libraries.
+
 ## Usage
 
 ```scala

--- a/src/test/scala/io/github/andrebeat/pool/PoolSpec.scala
+++ b/src/test/scala/io/github/andrebeat/pool/PoolSpec.scala
@@ -53,6 +53,27 @@ abstract class PoolSpec[P[_ <: AnyRef] <: Pool[_]](implicit ct: ClassTag[P[_]]) 
       i === 2
     }
 
+    "never create objects if there are any available on the pool (regression)" >> {
+      var i = 0
+
+      val p = Pool(2, () => { i += 1; new Object })
+      p.live() === 0
+      p.size() === 0
+      i === 0
+
+      p.acquire().release()
+
+      p.live() === 1
+      p.size() === 1
+      i === 1
+
+      p.acquire()
+
+      p.live() === 1
+      p.size() === 0
+      i === 1
+    }
+
     "allow filling the pool" >> {
       val p = Pool(3, () => new Object)
       p.live() === 0


### PR DESCRIPTION
Currently objects are created eagerly because the first thing that is tested is whether it is possible to create a new instance, and only then do we try to take from the queue. 

This PR reverses the logic, we now `poll` the queue first to check whether an object is available and only then try create a new object.
