### PR TITLE
Dilate timeouts according to number of cores

### DIFF
--- a/src/test/scala/io/github/andrebeat/pool/ExpiringPoolSpec.scala
+++ b/src/test/scala/io/github/andrebeat/pool/ExpiringPoolSpec.scala
@@ -2,7 +2,7 @@ package io.github.andrebeat.pool
 
 import scala.concurrent.duration._
 
-class ExpiringPoolSpec extends PoolSpec[ExpiringPool] {
+class ExpiringPoolSpec extends PoolSpec[ExpiringPool] with TestHelper {
   def Pool[A <: AnyRef](
     capacity: Int,
     factory: () => A,
@@ -19,7 +19,7 @@ class ExpiringPoolSpec extends PoolSpec[ExpiringPool] {
       p.size() === 3
       p.live() === 3
 
-      Thread.sleep(200)
+      sleep(200.millis)
 
       p.size() === 0
       p.live() === 0
@@ -34,7 +34,7 @@ class ExpiringPoolSpec extends PoolSpec[ExpiringPool] {
       p.size() === 2
       p.live() === 3
 
-      Thread.sleep(200)
+      sleep(200.millis)
 
       p.size() === 0
       p.live() === 1
@@ -44,7 +44,7 @@ class ExpiringPoolSpec extends PoolSpec[ExpiringPool] {
       p.size() === 1
       p.live() === 1
 
-      Thread.sleep(200)
+      sleep(200.millis)
 
       p.size() === 0
       p.live() === 0

--- a/src/test/scala/io/github/andrebeat/pool/TestHelper.scala
+++ b/src/test/scala/io/github/andrebeat/pool/TestHelper.scala
@@ -1,0 +1,12 @@
+package io.github.andrebeat.pool
+
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration.Duration
+
+trait TestHelper {
+  val cores = Runtime.getRuntime.availableProcessors
+  val timeFactor = 8 / math.min(8, cores)
+
+  def sleep(d: Duration) = Thread.sleep((d * timeFactor).toMillis)
+  def await[A](f: Future[A], d: Duration) = Await.result(f, d * timeFactor)
+}

--- a/src/test/scala/io/github/andrebeat/pool/TestHelper.scala
+++ b/src/test/scala/io/github/andrebeat/pool/TestHelper.scala
@@ -2,11 +2,11 @@ package io.github.andrebeat.pool
 
 import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration.Duration
+import scala.util.Properties
 
 trait TestHelper {
-  val cores = Runtime.getRuntime.availableProcessors
-  val timeFactor = 8 / math.min(8, cores)
+  val timeDilationFactor = Properties.envOrNone("TIME_DILATION_FACTOR").map(_.toInt).getOrElse(1)
 
-  def sleep(d: Duration) = Thread.sleep((d * timeFactor).toMillis)
-  def await[A](f: Future[A], d: Duration) = Await.result(f, d * timeFactor)
+  def sleep(d: Duration) = Thread.sleep((d * timeDilationFactor).toMillis)
+  def await[A](f: Future[A], d: Duration) = Await.result(f, d * timeDilationFactor)
 }


### PR DESCRIPTION
The tests that rely on timeouts/sleeping fail spuriously on Travis. This PR dilates all the timeouts according to the number of CPU cores in the system.
