### PR TITLE
Lease use function

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,19 @@ lease.use { o =>
 // The object is returned to the pool at this point
 ```
 
-It is also possible to get a value from a lease and release (or invalidate) it manually.
+All of the different pool features are exposed in the `Pool` companion object `apply` method:
+
+```scala
+Pool(
+  capacity: Int,                                       // the maximum capacity of the pool
+  factory: () => A,                                    // the function used to create new objects in the pool
+  referenceType: ReferenceType = ReferenceType.Strong, // the reference type of objects in the pool
+  maxIdleTime: Duration = Duration.Inf,                // the maximum amount of the time that objects are allowed to idle in the pool before being evicted
+  reset: A => Unit = { _: A => () },                   // the function used to reset objects in the pool (called when leasing an object from the pool)
+  dispose: A => Unit = { _: A => () })                 // the function used to destroy an object from the pool
+```
+
+It is also possible to get a value from a lease and release it (or invalidate) manually.
 
 ```scala
 import io.github.andrebeat.pool._

--- a/README.md
+++ b/README.md
@@ -41,14 +41,32 @@ libraries.
 
 ## Usage
 
+The basic usage of the pool is shown below:
+
 ```scala
 import io.github.andrebeat.pool._
 
 // Creating a `Pool[Object]` with a capacity of 2 instances
 val pool = Pool(2, () => new Object)
 
-// Acquiring a lease on an object from the pool
+// Acquiring a lease on an object from the pool (blocking if none available)
 val lease = pool.acquire()
+
+// Using the lease
+lease.use { o =>
+  println(o)
+}
+
+// The object is returned to the pool at this point
+```
+
+It is also possible to get a value from a lease and release (or invalidate) it manually.
+
+```scala
+import io.github.andrebeat.pool._
+
+// Creating a `Pool[Object]` with a capacity of 2 instances
+val pool = Pool(2, () => new Object)
 
 // Getting the value from the lease
 val obj = lease.get()
@@ -76,6 +94,8 @@ lease.release
 pool.size
 // res4: Int = 1
 ```
+
+The API is documented in depth in the [Scaladoc](https://andrebeat.github.io/scala-pool/latest/api/index.html#io.github.andrebeat.pool.package).
 
 ## License
 

--- a/src/main/scala/io/github/andrebeat/pool/Pool.scala
+++ b/src/main/scala/io/github/andrebeat/pool/Pool.scala
@@ -45,7 +45,15 @@ trait Lease[A <: AnyRef] {
     * releasing it back to the pool after the function is run.
     *
     * If needed, it is possible to invalidate the lease from inside the provided
-    * function.
+    * function, for example:
+    *
+    * {{{
+    * val lease = pool.acquire()
+    * val x = lease.use { v =>
+    *   if (/* invalid condition */) { lease.invalidate(); None }
+    *   else Some(/* result */)
+    * }
+    * }}}
     *
     * It is important that no references are kept to the leased object after
     * this method finishes. For example, the following code is invalid since the

--- a/src/main/scala/io/github/andrebeat/pool/Pool.scala
+++ b/src/main/scala/io/github/andrebeat/pool/Pool.scala
@@ -47,6 +47,15 @@ trait Lease[A <: AnyRef] {
     * If needed, it is possible to invalidate the lease from inside the provided
     * function.
     *
+    * It is important that no references are kept to the leased object after
+    * this method finishes. For example, the following code is invalid since the
+    * variable `x` holds a reference to an object that was returned to the pool.
+    *
+    * {{{
+    * val lease = pool.acquire()
+    * val x = lease.use(identity)
+    * }}}
+    *
     * @tparam B the type of object returned by the function `f`
     * @param f a function that uses the value stored in the lease to produce a new value
     * @return the value produced by the function `f`.

--- a/src/test/scala/io/github/andrebeat/pool/ExpiringPoolSpec.scala
+++ b/src/test/scala/io/github/andrebeat/pool/ExpiringPoolSpec.scala
@@ -3,7 +3,7 @@ package io.github.andrebeat.pool
 import scala.concurrent.duration._
 
 class ExpiringPoolSpec extends PoolSpec[ExpiringPool] with TestHelper {
-  def Pool[A <: AnyRef](
+  def pool[A <: AnyRef](
     capacity: Int,
     factory: () => A,
     referenceType: ReferenceType = ReferenceType.Strong,

--- a/src/test/scala/io/github/andrebeat/pool/PoolSpec.scala
+++ b/src/test/scala/io/github/andrebeat/pool/PoolSpec.scala
@@ -277,6 +277,34 @@ abstract class PoolSpec[P[_ <: AnyRef] <: Pool[_]](implicit ct: ClassTag[P[_]])
 
         l2.get() must throwAn[IllegalStateException]
       }
+
+      "have a `use` method that releases an object after its used" in {
+        val p = pool(1, () => new Object)
+
+        val l1 = p.acquire()
+        p.size() === 0
+
+        l1.use { o =>
+          ()
+        }
+
+        l1.get() must throwAn[IllegalStateException]
+        p.size() === 1
+      }
+
+      "allow invalidating an object inside the `use` method" in {
+        val p = pool(1, () => new Object)
+
+        val l1 = p.acquire()
+        p.size() === 0
+
+        l1.use { o =>
+          l1.invalidate()
+        }
+
+        l1.get() must throwAn[IllegalStateException]
+        p.size() === 0
+      }
     }
   }
 }

--- a/src/test/scala/io/github/andrebeat/pool/PoolSpec.scala
+++ b/src/test/scala/io/github/andrebeat/pool/PoolSpec.scala
@@ -11,7 +11,7 @@ import scala.reflect.ClassTag
 abstract class PoolSpec[P[_ <: AnyRef] <: Pool[_]](implicit ct: ClassTag[P[_]])
     extends Specification
     with TestHelper {
-  def Pool[A <: AnyRef](
+  def pool[A <: AnyRef](
     capacity: Int,
     factory: () => A,
     referenceType: ReferenceType = ReferenceType.Strong,
@@ -21,12 +21,12 @@ abstract class PoolSpec[P[_ <: AnyRef] <: Pool[_]](implicit ct: ClassTag[P[_]])
 
   s"A ${ct.runtimeClass.getSimpleName}" should {
     "have a capacity" >> {
-      val p = Pool(3, () => new Object)
+      val p = pool(3, () => new Object)
       p.capacity() === 3
     }
 
     "return the number of pooled, live and leased objects" >> {
-      val p = Pool(3, () => new Object)
+      val p = pool(3, () => new Object)
       p.acquire()
 
       p.size() === 0
@@ -37,7 +37,7 @@ abstract class PoolSpec[P[_ <: AnyRef] <: Pool[_]](implicit ct: ClassTag[P[_]])
     "create objects lazily" >> {
       var i = 0
 
-      val p = Pool(2, () => { i += 1; new Object })
+      val p = pool(2, () => { i += 1; new Object })
       p.live() === 0
       p.size() === 0
       i === 0
@@ -58,7 +58,7 @@ abstract class PoolSpec[P[_ <: AnyRef] <: Pool[_]](implicit ct: ClassTag[P[_]])
     "never create objects if there are any available on the pool (regression)" >> {
       var i = 0
 
-      val p = Pool(2, () => { i += 1; new Object })
+      val p = pool(2, () => { i += 1; new Object })
       p.live() === 0
       p.size() === 0
       i === 0
@@ -77,7 +77,7 @@ abstract class PoolSpec[P[_ <: AnyRef] <: Pool[_]](implicit ct: ClassTag[P[_]])
     }
 
     "allow filling the pool" >> {
-      val p = Pool(3, () => new Object)
+      val p = pool(3, () => new Object)
       p.live() === 0
       p.size() === 0
 
@@ -88,7 +88,7 @@ abstract class PoolSpec[P[_ <: AnyRef] <: Pool[_]](implicit ct: ClassTag[P[_]])
     }
 
     "fill the pool taking into account live objects outside the pool" >> {
-      val p = Pool(3, () => new Object)
+      val p = pool(3, () => new Object)
       p.live() === 0
       p.size() === 0
 
@@ -100,7 +100,7 @@ abstract class PoolSpec[P[_ <: AnyRef] <: Pool[_]](implicit ct: ClassTag[P[_]])
     }
 
     "allow draining the pool" >> {
-      val p = Pool(3, () => new Object)
+      val p = pool(3, () => new Object)
       p.fill()
       p.size() === 3
 
@@ -111,7 +111,7 @@ abstract class PoolSpec[P[_ <: AnyRef] <: Pool[_]](implicit ct: ClassTag[P[_]])
     }
 
     "block when no objects available and all objects have been created" >> {
-      val p = Pool(3, () => new Object)
+      val p = pool(3, () => new Object)
       p.fill()
 
       p.acquire()
@@ -131,7 +131,7 @@ abstract class PoolSpec[P[_ <: AnyRef] <: Pool[_]](implicit ct: ClassTag[P[_]])
     }
 
     "only block until a given duration when trying to acquire an object" >> {
-      val p = Pool[Object](3, () => new Object)
+      val p = pool[Object](3, () => new Object)
       p.fill()
 
       p.acquire()
@@ -149,7 +149,7 @@ abstract class PoolSpec[P[_ <: AnyRef] <: Pool[_]](implicit ct: ClassTag[P[_]])
       "when filling" >> {
         var i = 0
 
-        val p = Pool(3, () => new Object, reset = { _: Object => i += 1 })
+        val p = pool(3, () => new Object, reset = { _: Object => i += 1 })
         p.fill()
 
         p.size() === 3
@@ -159,7 +159,7 @@ abstract class PoolSpec[P[_ <: AnyRef] <: Pool[_]](implicit ct: ClassTag[P[_]])
       "when releasing" >> {
         var i = 0
 
-        val p = Pool(3, () => new Object, reset = { _: Object => i += 1 })
+        val p = pool(3, () => new Object, reset = { _: Object => i += 1 })
         p.acquire().release()
 
         i === 1
@@ -170,7 +170,7 @@ abstract class PoolSpec[P[_ <: AnyRef] <: Pool[_]](implicit ct: ClassTag[P[_]])
       "when invalidated" >> {
         var i = 0
 
-        val p = Pool(3, () => new Object, dispose = { _: Object => i += 1 })
+        val p = pool(3, () => new Object, dispose = { _: Object => i += 1 })
         p.acquire().invalidate()
 
         i === 1
@@ -179,7 +179,7 @@ abstract class PoolSpec[P[_ <: AnyRef] <: Pool[_]](implicit ct: ClassTag[P[_]])
       "when draining" >> {
         var i = 0
 
-        val p = Pool(3, () => new Object, dispose = { _: Object => i += 1 })
+        val p = pool(3, () => new Object, dispose = { _: Object => i += 1 })
         p.fill()
         p.drain()
 
@@ -189,7 +189,7 @@ abstract class PoolSpec[P[_ <: AnyRef] <: Pool[_]](implicit ct: ClassTag[P[_]])
       "when added to an already full pool" >> {
         // This situtation should never happen in a normal usage of the pool
         var i = 0
-        val p = Pool(3, () => new Object, dispose = { _: Object => i += 1 })
+        val p = pool(3, () => new Object, dispose = { _: Object => i += 1 })
 
         p.fill()
         val l = p.acquire()
@@ -216,7 +216,7 @@ abstract class PoolSpec[P[_ <: AnyRef] <: Pool[_]](implicit ct: ClassTag[P[_]])
 
     "handle GC-based eviction" >> {
       var i = 0
-      val p = Pool(3, () => { i += 1; new Object }, referenceType = ReferenceType.Weak)
+      val p = pool(3, () => { i += 1; new Object }, referenceType = ReferenceType.Weak)
 
       p.fill()
 
@@ -233,7 +233,7 @@ abstract class PoolSpec[P[_ <: AnyRef] <: Pool[_]](implicit ct: ClassTag[P[_]])
 
     s"A ${ct.runtimeClass.getSimpleName} Lease" should {
       "allow being invalidated and removed from the pool" >> {
-        val p = Pool(3, () => new Object)
+        val p = pool(3, () => new Object)
 
         p.fill()
 
@@ -248,7 +248,7 @@ abstract class PoolSpec[P[_ <: AnyRef] <: Pool[_]](implicit ct: ClassTag[P[_]])
       }
 
       "allow being released back to the pool" >> {
-        val p = Pool(3, () => new Object)
+        val p = pool(3, () => new Object)
 
         p.fill()
 
@@ -265,7 +265,7 @@ abstract class PoolSpec[P[_ <: AnyRef] <: Pool[_]](implicit ct: ClassTag[P[_]])
       }
 
       "throw an exception when reading from an invalidated or released lease" >> {
-        val p = Pool(3, () => new Object)
+        val p = pool(3, () => new Object)
 
         val l1 = p.acquire()
         l1.invalidate()

--- a/src/test/scala/io/github/andrebeat/pool/PoolSpec.scala
+++ b/src/test/scala/io/github/andrebeat/pool/PoolSpec.scala
@@ -227,7 +227,7 @@ abstract class PoolSpec[P[_ <: AnyRef] <: Pool[_]](implicit ct: ClassTag[P[_]])
 
       p.acquire()
 
-      // A new object add to be created since the existing ones were invalidated by the GC
+      // A new object had to be created since the existing ones were invalidated by the GC
       i === 4
     }
 

--- a/src/test/scala/io/github/andrebeat/pool/SimplePoolSpec.scala
+++ b/src/test/scala/io/github/andrebeat/pool/SimplePoolSpec.scala
@@ -1,7 +1,7 @@
 package io.github.andrebeat.pool
 
 class SimplePoolSpec extends PoolSpec[SimplePool] {
-  def Pool[A <: AnyRef](
+  def pool[A <: AnyRef](
     capacity: Int,
     factory: () => A,
     referenceType: ReferenceType = ReferenceType.Strong,


### PR DESCRIPTION
This PR adds a utility method `use` to the lease, that receives a function to operate on the leased object and releases the object back to the pool afterwards.
