### PR TITLE
Health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
   - object invalidation
   - capping the number of pooled objects
   - creating new objects lazily, as needed
+  - health checking
   - time-based pool eviction (idle instances)
   - GC-based pool eviction (soft and weak references)
   - efficient thread-safety

--- a/src/main/scala/io/github/andrebeat/pool/ArrayBlockingQueuePool.scala
+++ b/src/main/scala/io/github/andrebeat/pool/ArrayBlockingQueuePool.scala
@@ -23,7 +23,10 @@ abstract class ArrayBlockingQueuePool[A <: AnyRef](
     val referenceType: ReferenceType
 ) extends Pool[A] { pool =>
   abstract protected class Item(val r: Ref[A]) {
-    def isDefined(): Boolean = r.toOption().isDefined
+    def isDefined(): Boolean = {
+      val ro = r.toOption
+      ro.isDefined && healthCheck(ro.get)
+    }
 
     /**
       * This method should only be called from this class and it is guaranteed that the value is

--- a/src/main/scala/io/github/andrebeat/pool/ExpiringPool.scala
+++ b/src/main/scala/io/github/andrebeat/pool/ExpiringPool.scala
@@ -15,7 +15,8 @@ class ExpiringPool[A <: AnyRef](
     val maxIdleTime: Duration,
     _factory: () => A,
     _reset: A => Unit,
-    _dispose: A => Unit
+    _dispose: A => Unit,
+    _healthCheck: A => Boolean
 ) extends ArrayBlockingQueuePool[A](capacity, referenceType) {
 
   implicit private[this] def function2TimerTask[A](f: () => A) = new TimerTask() { def run() = f() }
@@ -42,6 +43,7 @@ class ExpiringPool[A <: AnyRef](
   @inline protected[this] def factory() = _factory()
   @inline protected[this] def dispose(a: A) = _dispose(a)
   @inline protected[this] def reset(a: A) = _reset(a)
+  @inline protected[this] def healthCheck(a: A) = _healthCheck(a)
 
   @inline protected[this] def newItem(a: A) = {
     adder.increment()
@@ -66,7 +68,8 @@ object ExpiringPool {
     maxIdleTime: Duration,
     factory: () => A,
     reset: A => Unit = { _: A => () },
-    dispose: A => Unit = { _: A => () }
+    dispose: A => Unit = { _: A => () },
+    healthCheck: A => Boolean = { _: A => true }
   ) =
-    new ExpiringPool(capacity, referenceType, maxIdleTime, factory, reset, dispose)
+    new ExpiringPool(capacity, referenceType, maxIdleTime, factory, reset, dispose, healthCheck)
 }

--- a/src/main/scala/io/github/andrebeat/pool/SimplePool.scala
+++ b/src/main/scala/io/github/andrebeat/pool/SimplePool.scala
@@ -11,12 +11,14 @@ class SimplePool[A <: AnyRef](
     referenceType: ReferenceType,
     _factory: () => A,
     _reset: A => Unit,
-    _dispose: A => Unit
+    _dispose: A => Unit,
+    _healthCheck: A => Boolean
 ) extends ArrayBlockingQueuePool[A](capacity, referenceType) {
 
   @inline protected[this] def factory() = _factory()
   @inline protected[this] def dispose(a: A) = _dispose(a)
   @inline protected[this] def reset(a: A) = _reset(a)
+  @inline protected[this] def healthCheck(a: A) = _healthCheck(a)
 
   final protected class SimpleItem(a: Ref[A]) extends Item(a) {
     def consume() = {}
@@ -35,7 +37,8 @@ object SimplePool {
     referenceType: ReferenceType,
     factory: () => A,
     reset: A => Unit = { _: A => () },
-    dispose: A => Unit = { _: A => () }
+    dispose: A => Unit = { _: A => () },
+    healthCheck: A => Boolean = { _: A => true }
   ) =
-    new SimplePool(capacity, referenceType, factory, reset, dispose)
+    new SimplePool(capacity, referenceType, factory, reset, dispose, healthCheck)
 }

--- a/src/main/scala/io/github/andrebeat/pool/package.scala
+++ b/src/main/scala/io/github/andrebeat/pool/package.scala
@@ -6,6 +6,7 @@ package io.github.andrebeat
   *   - object invalidation
   *   - capping the number of pooled objects
   *   - creating new objects lazily, as needed
+  *   - health checking
   *   - time-based pool eviction (idle instances)
   *   - GC-based pool eviction (soft and weak references)
   *   - efficient thread-safety

--- a/src/test/scala/io/github/andrebeat/pool/ExpiringPoolSpec.scala
+++ b/src/test/scala/io/github/andrebeat/pool/ExpiringPoolSpec.scala
@@ -8,8 +8,9 @@ class ExpiringPoolSpec extends PoolSpec[ExpiringPool] with TestHelper {
     factory: () => A,
     referenceType: ReferenceType = ReferenceType.Strong,
     reset: A => Unit = { _: A => () },
-    dispose: A => Unit = { _: A => () }
-  ) = ExpiringPool(capacity, referenceType, 42.hours, factory, reset, dispose)
+    dispose: A => Unit = { _: A => () },
+    healthCheck: A => Boolean = { _: A => true }
+  ) = ExpiringPool(capacity, referenceType, 42.hours, factory, reset, dispose, healthCheck)
 
   "A ExpiringPool" should {
     "evict idle objects" >> {

--- a/src/test/scala/io/github/andrebeat/pool/SimplePoolSpec.scala
+++ b/src/test/scala/io/github/andrebeat/pool/SimplePoolSpec.scala
@@ -6,6 +6,7 @@ class SimplePoolSpec extends PoolSpec[SimplePool] {
     factory: () => A,
     referenceType: ReferenceType = ReferenceType.Strong,
     reset: A => Unit = { _: A => () },
-    dispose: A => Unit = { _: A => () }
-  ) = SimplePool(capacity, referenceType, factory, reset, dispose)
+    dispose: A => Unit = { _: A => () },
+    healthCheck: A => Boolean = { _: A => true }
+  ) = SimplePool(capacity, referenceType, factory, reset, dispose, healthCheck)
 }


### PR DESCRIPTION
Add support for health checking objects before leasing them from the pool (e.g. is the socket still open?).
