### PR TITLE
Close pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,13 @@ lease.release
 // Its now in the pool waiting to be reused
 pool.size
 // res4: Int = 1
+
+// Closes this pool, properly disposing of each pooled object and 
+// releasing any resources associated with the pool
+pool.close()
 ```
 
-The API is documented in depth in the [Scaladoc](https://andrebeat.github.io/scala-pool/latest/api/index.html).
+The API is documented in depth in the [Scaladoc](https://andrebeat.github.io/scala-pool/).
 
 ## License
 

--- a/src/main/scala/io/github/andrebeat/pool/ArrayBlockingQueuePool.scala
+++ b/src/main/scala/io/github/andrebeat/pool/ArrayBlockingQueuePool.scala
@@ -80,8 +80,12 @@ abstract class ArrayBlockingQueuePool[A <: AnyRef](
 
   private class PoolLease(protected val a: A) extends Lease[A] {
     protected def handleRelease() = {
-      reset(a)
-      tryOffer(a)
+      if (!closed.get()) {
+        reset(a)
+        tryOffer(a)
+      } else {
+        destroy(a)
+      }
     }
 
     protected def handleInvalidate() = {

--- a/src/main/scala/io/github/andrebeat/pool/ExpiringPool.scala
+++ b/src/main/scala/io/github/andrebeat/pool/ExpiringPool.scala
@@ -50,6 +50,10 @@ class ExpiringPool[A <: AnyRef](
   @inline protected[this] def reset(a: A) = _reset(a)
   @inline protected[this] def healthCheck(a: A) = _healthCheck(a)
 
+  @inline protected[this] def handleClose() = {
+    timer.cancel()
+  }
+
   @inline protected[this] def newItem(a: A) = {
     adder.increment()
     val id = adder.count()

--- a/src/main/scala/io/github/andrebeat/pool/ExpiringPool.scala
+++ b/src/main/scala/io/github/andrebeat/pool/ExpiringPool.scala
@@ -42,7 +42,7 @@ class ExpiringPool[A <: AnyRef](
     }
   }
 
-  private[this] val timer = new Timer(s"scala-pool-${ExpiringPool.count.getAndIncrement}", true)
+  private[pool] val timer = new Timer(s"scala-pool-${ExpiringPool.count.getAndIncrement}", true)
   private[this] val adder = Adder()
 
   @inline protected[this] def factory() = _factory()

--- a/src/main/scala/io/github/andrebeat/pool/Pool.scala
+++ b/src/main/scala/io/github/andrebeat/pool/Pool.scala
@@ -28,6 +28,8 @@ trait Lease[A <: AnyRef] {
     * Releases the object back to the pool for reuse. When releasing an object it is mandatory that
     * there are no references to the returned object.
     *
+    * When an object is released to a pool that has already been closed it is "destroyed".
+    *
     * If the lease has already been released or invalidated this method does nothing.
     */
   def release(): Unit = if (dirty.compareAndSet(false, true)) handleRelease

--- a/src/main/scala/io/github/andrebeat/pool/SimplePool.scala
+++ b/src/main/scala/io/github/andrebeat/pool/SimplePool.scala
@@ -24,6 +24,8 @@ class SimplePool[A <: AnyRef](
     def offerSuccess() = {}
   }
 
+  @inline protected[this] def handleClose() = {}
+
   @inline protected[this] def newItem(a: A): Item = new SimpleItem(Ref(a, referenceType))
 }
 

--- a/src/test/scala/io/github/andrebeat/pool/ExpiringPoolSpec.scala
+++ b/src/test/scala/io/github/andrebeat/pool/ExpiringPoolSpec.scala
@@ -50,5 +50,13 @@ class ExpiringPoolSpec extends PoolSpec[ExpiringPool] with TestHelper {
       p.size() === 0
       p.live() === 0
     }
+
+    "shutdown the pool timer when it is closed" >> {
+      val p = ExpiringPool(3, ReferenceType.Strong, 50.millis, () => new Object)
+      p.close()
+
+      p.timer.scheduleAtFixedRate(null, 1, 1) must
+        throwA[IllegalStateException](message = "Timer already cancelled.")
+    }
   }
 }

--- a/src/test/scala/io/github/andrebeat/pool/PoolSpec.scala
+++ b/src/test/scala/io/github/andrebeat/pool/PoolSpec.scala
@@ -349,6 +349,20 @@ abstract class PoolSpec[P[_ <: AnyRef] <: Pool[_]](implicit ct: ClassTag[P[_]])
         l1.get() must throwAn[IllegalStateException]
         p.size() === 0
       }
+
+      "destroy the object when it is returned to a closed pool" >> {
+        val p = pool(1, () => new Object)
+
+        val l1 = p.acquire()
+
+        p.close()
+        p.live() === 1
+
+        l1.release()
+
+        p.live() === 0
+        p.size() === 0
+      }
     }
   }
 }


### PR DESCRIPTION
Add method to close a pool, properly disposing of each pooled object, and releasing any resources associated with the pool (e.g. background timer threads).

Fixes #11.
