### PR TITLE
Update site definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.andrebeat/scala-pool_2.11.svg)](https://maven-badges.herokuapp.com/maven-central/io.github.andrebeat/scala-pool_2.11)
 [![Coverage](https://img.shields.io/coveralls/andrebeat/scala-pool/master.svg)](https://coveralls.io/github/andrebeat/scala-pool)
 [![License](https://img.shields.io/dub/l/vibe-d.svg)](https://raw.githubusercontent.com/andrebeat/scala-pool/master/LICENSE)
-[![Scaladoc](http://javadoc-badge.appspot.com/io.github.andrebeat/scala-pool_2.11.svg?label=scaladoc)](http://javadoc-badge.appspot.com/io.github.andrebeat/scala-pool_2.11)
-[![Scaladoc](https://img.shields.io/badge/scaladoc-latest-brightgreen.svg)](https://andrebeat.github.io/scala-pool/latest/api/index.html)
+[![Scaladoc](http://javadoc-badge.appspot.com/io.github.andrebeat/scala-pool_2.11.svg?label=scaladoc)](http://javadoc-badge.appspot.com/io.github.andrebeat/scala-pool_2.11#io.github.andrebeat.pool.package)
+[![Scaladoc](https://img.shields.io/badge/scaladoc-latest-brightgreen.svg)](https://andrebeat.github.io/scala-pool)
 
 ## Installation
 

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>scala-pool</title>
+    <script>
+     (function() {
+       window.location.replace("latest/api/index.html#io.github.andrebeat.pool.package");
+     })();
+    </script>
+  </head>
+  <body>
+    <a href="latest/api/index.html#io.github.andrebeat.pool.package">
+      Go to the project documentation
+    </a>
+  </body>
+</html>


### PR DESCRIPTION
Updates the scaladoc links in the README to point at the more useful `io.github.andrebeat.pool` package documentation. Added an `index.html` to the github pages that redirects to the latest scaladoc.
